### PR TITLE
Bug (ET-861 navbar indicator) Temporary fix for job status indicator

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -23,4 +23,4 @@
   <a *ngIf="isLoggedIn" mat-menu-item routerLink="/projects" class="new-font" style="color: #ff5252;" (click)="logout()"> Log out </a>
 </mat-menu>
 
-<router-outlet  (activate)="newRoute()"></router-outlet>
+<!-- <router-outlet  (activate)="newRoute()"></router-outlet> -->


### PR DESCRIPTION
Job status indicator moved to the bottom of the screen because of an extra `router-outlet` component that was used to highlight the current page in the hamburger menu.

Temporary fix removes the highlighting but fixes the job status.